### PR TITLE
Fixed spacing on bottom of refraim page so buttons don't get covered by navbar

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -27,3 +27,7 @@ body {
 .history {
   padding-top: 20px
 }
+
+.validating, .validated {
+  padding-bottom: 60px
+}

--- a/src/components/ConversationBox.jsx
+++ b/src/components/ConversationBox.jsx
@@ -150,16 +150,19 @@ function ConversationBox() {
 
                         </div>
                         : validation === 'validating' ?
-                            <div>
+                            <div className='validating'>
                                 <p>Does this sound accurate?</p>
                                 <Button variant="contained"
                                     onClick={() => handleValidationResponse('yes')}>Yes</Button>
                                 <Button variant="contained"
                                     onClick={() => handleValidationResponse('no')}>No</Button>
                             </div>
-                            : validation === 'validated' ?
+                            :validation === 'validated' ? 
+                            <div className='validated'>
                                 <Button variant="contained"
                                     href='/complete'>Complete</Button>
+                            </div>
+                            
                                 : null
                 )}
 


### PR DESCRIPTION
- WIP: temporary commit
- Working on making second call to OpenAI API for reworded refraim. Not working quite yet.
- getting 'Cannot read properties of undefined (reading 'user_id')' in the PUT request
- Second call to OpenAI for reworded refraim is working
- fixed rendering of 'does this sound accurate' and buttons
- fixed spacing on bottom of refraim page so that buttons don't get covered by navbar
